### PR TITLE
check argument count

### DIFF
--- a/json.go
+++ b/json.go
@@ -30,6 +30,10 @@ var api = map[string]lua.LGFunction{
 }
 
 func apiDecode(L *lua.LState) int {
+	if L.GetTop() != 1 {
+		L.Error(lua.LString("bad argument #1 to decode"), 1)
+		return 0
+	}
 	str := L.CheckString(1)
 
 	value, err := Decode(L, []byte(str))
@@ -43,6 +47,10 @@ func apiDecode(L *lua.LState) int {
 }
 
 func apiEncode(L *lua.LState) int {
+	if L.GetTop() != 1 {
+		L.Error(lua.LString("bad argument #1 to encode"), 1)
+		return 0
+	}
 	value := L.CheckAny(1)
 
 	data, err := Encode(value)

--- a/json_test.go
+++ b/json_test.go
@@ -41,6 +41,15 @@ func TestSimple(t *testing.T) {
 
 	assert(json.decode("null") == nil)
 
+	local status, err = pcall(function() json.decode() end)
+	assert(err == "<string>:35: bad argument #1 to decode", err)
+	local status, err = pcall(function() json.decode(1,2) end)
+	assert(err == "<string>:37: bad argument #1 to decode", err)
+	local status, err = pcall(function() json.encode() end)
+	assert(err == "<string>:39: bad argument #1 to encode", err)
+	local status, err = pcall(function() json.encode(1,2) end)
+	assert(err == "<string>:41: bad argument #1 to encode", err)
+
 	assert(json.decode(json.encode({person={name = "tim",}})).person.name == "tim")
 
 	local obj = {


### PR DESCRIPTION
Check that the argument count for the json functions is always 1.

I got a PR to use gopher-json in [miniredis](https://github.com/alicebob/miniredis) and this is needed to make it behave like Redis does, but it might make sense anyway.

I didn't figure out how to make the test not have the linenumbers in them :(

The way errors are returned is how the Go Lua examples work, but it seems to differ from the other error cases. Not sure if that matters.
