### PR TITLE
encode: return an error instead of panicking for nested tables

### DIFF
--- a/json.go
+++ b/json.go
@@ -97,7 +97,7 @@ func (j jsonValue) MarshalJSON() (data []byte, err error) {
 		var obj map[string]jsonValue
 
 		if j.visited[converted] {
-			panic(errNested)
+			return nil, errNested
 		}
 		j.visited[converted] = true
 


### PR DESCRIPTION
Without the fix, tests fail:

```
=== RUN   TestSimple
--- FAIL: TestSimple (92.12s)
    json_test.go:66: cannot encode recursively nested tables to JSON
        stack traceback:
        	[G]: in function 'encode'
        	<string>:45: in main chunk
        	[G]: ?
FAIL
```
