### PR TITLE
Make go module, marshal userdata as json(null), and encode sparse arrays

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/layeh/gopher-json
+
+go 1.19
+
+require github.com/yuin/gopher-lua v0.0.0-20221210110428-332342483e3f

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/yuin/gopher-lua v0.0.0-20221210110428-332342483e3f h1:wihIB0V/mGpVYrL8I7n/WxVqWnP07CBXZ5uCgxUP1tI=
+github.com/yuin/gopher-lua v0.0.0-20221210110428-332342483e3f/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=

--- a/json.go
+++ b/json.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // Preload adds json to the given Lua state's package.preload table. After it
@@ -131,6 +131,9 @@ func (j jsonValue) MarshalJSON() (data []byte, err error) {
 		default:
 			err = errInvalidKeys
 		}
+	case *lua.LUserData:
+		data, err = json.Marshal(nil)
+		return
 	default:
 		err = invalidTypeError(j.LValue.Type())
 	}

--- a/json_test.go
+++ b/json_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 func TestSimple(t *testing.T) {
@@ -62,6 +62,8 @@ func TestSimple(t *testing.T) {
 		a[i] = i
 	end
 	assert(json.encode(a) == "[1,2,3,4,5]")
+
+	assert(json.encode(json) == nil)
 	`
 	s := lua.NewState()
 	defer s.Close()


### PR DESCRIPTION
To improve the gopher-json encoding aspects lua.UserData types detected are replaced as JSON `null` values and the encoding of sparse arrays is now possible where the key/index and value from the array item are combined to form the JSON value:

```
{
  1,
  2,
  [10] = 3
}
```

=> 

```
[
  1,
  2,
  "[10] = 3"
]
```